### PR TITLE
Feature: improved emoji support

### DIFF
--- a/lib/src/arc_text_painter.dart
+++ b/lib/src/arc_text_painter.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 
+import 'package:characters/characters.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_arc_text/src/enums.dart';
@@ -61,8 +62,8 @@ class ArcTextPainter {
         break;
     }
 
-    if (stretchAngle != null && _text.runes.length > 1) {
-      _interLetterAngle = (stretchAngle - finalAngle) / _text.runes.length;
+    if (stretchAngle != null && _text.characters.length > 1) {
+      _interLetterAngle = (stretchAngle - finalAngle) / _text.characters.length;
     }
   }
 
@@ -92,8 +93,8 @@ class ArcTextPainter {
   /// is drawn.
   double getFinalAngle() {
     double finalRotation = 0;
-    _text.runes.forEach((charCode) {
-      final translation = _getTranslation(String.fromCharCode(charCode));
+    _text.characters.forEach((graphemeCluster) {
+      final translation = _getTranslation(graphemeCluster);
       finalRotation += translation.alpha + _interLetterAngle;
     });
     return finalRotation - _interLetterAngle;
@@ -112,8 +113,8 @@ class ArcTextPainter {
   }
 
   void _drawText(Canvas canvas, int angleMultiplier, double heightOffset) {
-    _text.runes.forEach((charCode) {
-      final translation = _getTranslation(String.fromCharCode(charCode));
+    _text.characters.forEach((graphemeCluster) {
+      final translation = _getTranslation(graphemeCluster);
       final halfAngleOffset = translation.alpha / 2 * angleMultiplier;
       canvas.rotate(halfAngleOffset);
       _textPainter.paint(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+  characters: ^1.0.0
+
 dev_dependencies:
   mews_pedantic: ^0.1.1
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  characters: ^1.0.0
+  characters: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The current rendering based on runes has issues when rendering complex emojis (composed out of multiple unicode chars, e.g. 👨🏻‍💻 breaks down to several runes  👨 🏻  💻, see [emojipedia](https://emojipedia.org/man-technologist-light-skin-tone/) )

When using grapheme clusters (provided by [characters package](https://pub.dev/packages/characters)) this can be solved since they split text in visible / user-perceived characters.


Note: 8cf0f1d is based on the previous version of arc_text (pre null-safety) for a potential back-port