### PR TITLE
feat: Make TextStyle parameter optional

### DIFF
--- a/packages/flutter_arc_text/lib/src/arc_text.dart
+++ b/packages/flutter_arc_text/lib/src/arc_text.dart
@@ -97,12 +97,10 @@ class ArcText extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final DefaultTextStyle defaultTextStyle = DefaultTextStyle.of(context);
-    TextStyle? effectiveTextStyle = textStyle;
-    if (textStyle == null || textStyle!.inherit) {
-      effectiveTextStyle = defaultTextStyle.style.merge(textStyle);
-    }
+    TextStyle effectiveTextStyle = defaultTextStyle.style.merge(textStyle);
+
     if (MediaQuery.boldTextOf(context)) {
-      effectiveTextStyle = effectiveTextStyle!
+      effectiveTextStyle = effectiveTextStyle
           .merge(const TextStyle(fontWeight: FontWeight.bold));
     }
 

--- a/packages/flutter_arc_text/lib/src/arc_text.dart
+++ b/packages/flutter_arc_text/lib/src/arc_text.dart
@@ -8,7 +8,7 @@ class ArcText extends StatelessWidget {
     super.key,
     required this.radius,
     required this.text,
-    required this.textStyle,
+    this.textStyle,
     this.startAngle = 0,
     this.startAngleAlignment = StartAngleAlignment.start,
     this.direction = Direction.clockwise,
@@ -25,7 +25,7 @@ class ArcText extends StatelessWidget {
   final String text;
 
   /// TextStyle that will be applied to the text.
-  final TextStyle textStyle;
+  final TextStyle? textStyle;
 
   /// Initial angle (0 is top center, positive angle is clockwise).
   final double startAngle;
@@ -95,27 +95,39 @@ class ArcText extends StatelessWidget {
   final PainterDelegate painterDelegate;
 
   @override
-  Widget build(BuildContext context) => CustomPaint(
-        painter: _Painter(
-          radius: radius,
-          text: text,
-          textStyle: textStyle,
-          alignment: startAngleAlignment,
-          initialAngle: startAngle,
-          direction: direction,
-          placement: placement,
-          stretchAngle: stretchAngle,
-          interLetterAngle: interLetterAngle,
-          painterDelegate: painterDelegate,
-        ),
-      );
+  Widget build(BuildContext context) {
+    final DefaultTextStyle defaultTextStyle = DefaultTextStyle.of(context);
+    TextStyle? effectiveTextStyle = textStyle;
+    if (textStyle == null || textStyle!.inherit) {
+      effectiveTextStyle = defaultTextStyle.style.merge(textStyle);
+    }
+    if (MediaQuery.boldTextOf(context)) {
+      effectiveTextStyle = effectiveTextStyle!
+          .merge(const TextStyle(fontWeight: FontWeight.bold));
+    }
+
+    return CustomPaint(
+      painter: _Painter(
+        radius: radius,
+        text: text,
+        textStyle: effectiveTextStyle,
+        alignment: startAngleAlignment,
+        initialAngle: startAngle,
+        direction: direction,
+        placement: placement,
+        stretchAngle: stretchAngle,
+        interLetterAngle: interLetterAngle,
+        painterDelegate: painterDelegate,
+      ),
+    );
+  }
 }
 
 class _Painter extends CustomPainter {
   _Painter({
     required num radius,
     required String text,
-    required TextStyle textStyle,
+    TextStyle? textStyle,
     required StartAngleAlignment alignment,
     required double initialAngle,
     required Direction direction,

--- a/packages/flutter_arc_text/lib/src/arc_text_painter.dart
+++ b/packages/flutter_arc_text/lib/src/arc_text_painter.dart
@@ -8,7 +8,7 @@ class ArcTextPainter {
   ArcTextPainter({
     required num radius,
     required String text,
-    required TextStyle textStyle,
+    TextStyle? textStyle,
     StartAngleAlignment alignment = StartAngleAlignment.start,
     double initialAngle = 0,
     this.direction = Direction.clockwise,
@@ -62,7 +62,7 @@ class ArcTextPainter {
   }
 
   final String _text;
-  final TextStyle _textStyle;
+  final TextStyle? _textStyle;
   late final double _effectiveRadius;
   late final int _angleMultiplier;
   late final double _heightOffset;
@@ -152,7 +152,7 @@ double _getAlignmentOffset(StartAngleAlignment alignment, double angle) {
 
 double _calculateSweepAngle(
   TextPainter painter,
-  TextStyle style,
+  TextStyle? style,
   double radius,
   String text,
   double interLetterAngle,
@@ -174,7 +174,7 @@ double _calculateSweepAngle(
 /// Calculates width and central angle for the provided [letter].
 LetterTranslation _getTranslation(
   TextPainter painter,
-  TextStyle style,
+  TextStyle? style,
   double radius,
   String letter,
 ) {


### PR DESCRIPTION
Fixes https://github.com/ookami-kb/flutter_arc_text/issues/22

This is also rebased onto https://github.com/ookami-kb/flutter_arc_text/pull/24 to bring everything to a modern version, so I could actually run/test the examples.  But really this change is all in the single CL [Make TextStyle optional, and default it to the DefaultTextStyle](https://github.com/ookami-kb/flutter_arc_text/commit/5b7f25297120cd2a7493e667d682a21c166e8514)